### PR TITLE
Update index error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function findAllAfter(parent, index, test) {
   children = parent.children
   length = children.length
 
-  if (index === undefined) {
+  if (index === undefined || index === null) {
     throw new Error('Expected positive finite index or child node')
   } else if (index && typeof index !== 'number') {
     index = children.indexOf(index)

--- a/index.js
+++ b/index.js
@@ -18,12 +18,15 @@ function findAllAfter(parent, index, test) {
   children = parent.children
   length = children.length
 
-  if (index && index.type) {
-    index = children.indexOf(index)
-  }
-
-  if (isNaN(index) || index < 0 || index === Infinity) {
+  if (index === undefined) {
     throw new Error('Expected positive finite index or child node')
+  } else if (index && typeof index !== 'number') {
+    index = children.indexOf(index)
+    if (index < 0) {
+      throw new Error('Expected child node')
+    }
+  } else if (index < 0 || index === Infinity) {
+    throw new Error('Expected positive finite index')
   }
 
   while (++index < length) {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function findAllAfter(parent, index, test) {
     throw new Error('Expected positive finite index or child node')
   } else if (index && typeof index !== 'number') {
     index = children.indexOf(index)
-    if (index < 0) {
+    if (index === -1) {
       throw new Error('Expected child node')
     }
   }

--- a/index.js
+++ b/index.js
@@ -25,8 +25,11 @@ function findAllAfter(parent, index, test) {
     if (index < 0) {
       throw new Error('Expected child node')
     }
-  } else if (index < 0 || index === Infinity) {
-    throw new Error('Expected positive finite index')
+  }
+
+  if (typeof index !== 'number' || index < 0 || index === Infinity) {
+    console.log('Throw finite index')
+    throw new Error('Expected positive finite number as index')
   }
 
   while (++index < length) {

--- a/index.js
+++ b/index.js
@@ -28,7 +28,6 @@ function findAllAfter(parent, index, test) {
   }
 
   if (typeof index !== 'number' || index < 0 || index === Infinity) {
-    console.log('Throw finite index')
     throw new Error('Expected positive finite number as index')
   }
 

--- a/test.js
+++ b/test.js
@@ -33,11 +33,11 @@ test('unist-util-find-all-after', function(t) {
 
     assert.throws(function() {
       findAllAfter({type: 'foo', children: []}, -1)
-    }, /Expected positive finite index or child node/)
+    }, /Expected positive finite index/)
 
     assert.throws(function() {
       findAllAfter({type: 'foo', children: []}, {type: 'bar'})
-    }, /Expected positive finite index or child node/)
+    }, /Expected child node/)
   }, 'should fail without index')
 
   t.doesNotThrow(function() {

--- a/test.js
+++ b/test.js
@@ -30,15 +30,29 @@ test('unist-util-find-all-after', function(t) {
     assert.throws(function() {
       findAllAfter({type: 'foo', children: []})
     }, /Expected positive finite index or child node/)
+  }, 'should fail without index')
 
+  t.doesNotThrow(function() {
     assert.throws(function() {
       findAllAfter({type: 'foo', children: []}, -1)
-    }, /Expected positive finite index/)
+    }, /Expected positive finite number as index/)
+
+    assert.throws(function() {
+      findAllAfter({type: 'foo', children: []}, Infinity)
+    }, /Expected positive finite number as index/)
+
+    assert.throws(function() {
+      findAllAfter({type: 'foo', children: []}, false)
+    }, /Expected positive finite number as index/)
+
+    assert.throws(function() {
+      findAllAfter({type: 'foo', children: []}, '')
+    }, /Expected positive finite number as index/)
 
     assert.throws(function() {
       findAllAfter({type: 'foo', children: []}, {type: 'bar'})
     }, /Expected child node/)
-  }, 'should fail without index')
+  }, 'should fail with invalid index')
 
   t.doesNotThrow(function() {
     assert.throws(function() {


### PR DESCRIPTION
I've updated the error handling for invalid indexes.
The new version is compatible with the types I will be submitting shortly.

Error messages are now narrowed to the specific error.

<!--

Read the [contributing guidelines](https://github.com/syntax-tree/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/syntax-tree/.github/blob/master/support.md
https://github.com/syntax-tree/.github/blob/master/contributing.md
-->
